### PR TITLE
feat: migrate skills to MCP prompts for pdf, pptx, and docx servers

### DIFF
--- a/src/docx/src/docx/prompts.py
+++ b/src/docx/src/docx/prompts.py
@@ -19,6 +19,22 @@ def docx_workflow() -> str:
 - `convert_to_pdf` - Convert .docx to PDF
 - `convert_to_markdown` - Convert to markdown
 
+## Workflow Decision Tree
+
+### Reading/Analyzing Content
+- Text extraction: `pandoc --track-changes=all path-to-file.docx -o output.md`
+- Raw XML access: Unpack for comments, formatting, structure, media
+
+### Creating New Document
+→ Use **docx-js** workflow (see `docx_creation()` prompt)
+
+### Editing Existing Document
+- **Your own document + simple changes**: Basic OOXML editing
+- **Someone else's document**: Use **Redlining workflow** (recommended)
+- **Legal, academic, business, government docs**: Use **Redlining workflow** (required)
+
+See `docx_redlining()` and `docx_ooxml_reference()` prompts for details.
+
 ## Typical Workflows
 
 ### 1. Read Document Content
@@ -47,4 +63,270 @@ convert_to_pdf(docx_file="document.docx")
 - Requires pandoc for markdown conversion
 - Requires LibreOffice (soffice) for PDF conversion and validation
 - XML editing requires understanding of OOXML format
+"""
+
+
+@mcp.prompt()
+def docx_creation() -> str:
+    """Creating new Word documents with docx-js."""
+    return """# Creating New Word Documents with docx-js
+
+## Workflow
+
+1. **MANDATORY**: Read `docx-js.md` completely (~500 lines, no range limits)
+   - Detailed syntax, formatting rules, best practices
+2. Create JavaScript/TypeScript file using Document, Paragraph, TextRun components
+3. Export as .docx using Packer.toBuffer()
+
+## Basic Example
+
+```javascript
+const { Document, Packer, Paragraph, TextRun } = require("docx");
+const fs = require("fs");
+
+const doc = new Document({
+    sections: [{
+        properties: {},
+        children: [
+            new Paragraph({
+                children: [
+                    new TextRun({
+                        text: "Hello World",
+                        bold: true,
+                        size: 28,
+                    }),
+                ],
+            }),
+            new Paragraph({
+                text: "This is a simple document created with docx-js",
+            }),
+        ],
+    }],
+});
+
+Packer.toBuffer(doc).then(buffer => {
+    fs.writeFileSync("document.docx", buffer);
+});
+```
+
+## Key Components
+
+**Document** - Root container for sections
+**Section** - Page layout and orientation
+**Paragraph** - Text block with formatting
+**TextRun** - Inline text with styling (bold, italic, size, color)
+**Table** - Tabular data
+**Header/Footer** - Page headers and footers
+**Numbering** - Bulleted and numbered lists
+
+## Common Formatting
+
+**Text styling**: bold, italic, underline, size, color, font
+**Paragraph**: alignment, spacing, indentation, borders
+**Lists**: bullets, numbering, multi-level
+**Tables**: rows, columns, cell merging, borders
+**Page**: margins, orientation, size, headers/footers
+
+## Dependencies
+
+All dependencies should be installed. If not:
+- `npm install -g docx`
+"""
+
+
+@mcp.prompt()
+def docx_redlining() -> str:
+    """Tracked changes workflow for document review."""
+    return """# Redlining Workflow for Document Review
+
+## When to Use
+
+- Editing someone else's document
+- Legal, academic, business, or government docs
+- Any situation requiring change tracking
+
+## Principle: Minimal, Precise Edits
+
+**Only mark text that actually changes**. Don't repeat unchanged text.
+
+**BAD** - Replaces entire sentence:
+```python
+'<w:del><w:r><w:delText>The term is 30 days.</w:delText></w:r></w:del><w:ins><w:r><w:t>The term is 60 days.</w:t></w:r></w:ins>'
+```
+
+**GOOD** - Only marks what changed:
+```python
+'<w:r w:rsidR="00AB12CD"><w:t>The term is </w:t></w:r><w:del><w:r><w:delText>30</w:delText></w:r></w:del><w:ins><w:r><w:t>60</w:t></w:r></w:ins><w:r w:rsidR="00AB12CD"><w:t> days.</w:t></w:r>'
+```
+
+## Workflow
+
+### 1. Get Markdown Representation
+```bash
+pandoc --track-changes=all path-to-file.docx -o current.md
+```
+
+### 2. Identify and Group Changes
+
+**Batching strategy**: Group 3-10 related changes per batch
+
+**Location methods** (for finding in XML):
+- Section/heading numbers (e.g., "Section 3.2")
+- Paragraph identifiers
+- Grep patterns with unique surrounding text
+- Document structure (e.g., "first paragraph")
+- **DO NOT use markdown line numbers**
+
+**Batch organization**:
+- By section: "Batch 1: Section 2 amendments"
+- By type: "Batch 1: Date corrections"
+- By complexity: Simple text first, then structural
+- Sequential: "Batch 1: Pages 1-3"
+
+### 3. Read Documentation and Unpack
+
+**MANDATORY**: Read `ooxml.md` completely (~600 lines, no range limits)
+- Focus on "Document Library" and "Tracked Change Patterns" sections
+
+**Unpack**:
+```bash
+python ooxml/scripts/unpack.py <file.docx> <dir>
+```
+
+**Note the suggested RSID** from unpack output for tracked changes
+
+### 4. Implement Changes in Batches
+
+For each batch (3-10 related changes):
+
+**a. Map text to XML**: Grep for text in `word/document.xml` to verify `<w:r>` splitting
+
+**b. Create and run script**: Use `get_node` to find nodes, implement changes, `doc.save()`
+
+**Note**: Always grep `word/document.xml` before writing script (line numbers change after each run)
+
+### 5. Pack the Document
+
+After all batches:
+```bash
+python ooxml/scripts/pack.py unpacked reviewed-document.docx
+```
+
+### 6. Final Verification
+
+```bash
+# Convert to markdown
+pandoc --track-changes=all reviewed-document.docx -o verification.md
+
+# Verify changes
+grep "original phrase" verification.md  # Should NOT find
+grep "replacement phrase" verification.md  # Should find
+```
+
+## Key File Structures
+
+- `word/document.xml` - Main document
+- `word/comments.xml` - Comments
+- `word/media/` - Embedded images
+- Tracked changes: `<w:ins>` (insertions), `<w:del>` (deletions)
+"""
+
+
+@mcp.prompt()
+def docx_ooxml_reference() -> str:
+    """OOXML editing patterns and Document library reference."""
+    return """# OOXML Editing Reference
+
+## Unpacking and Packing
+
+### Unpack
+```bash
+python ooxml/scripts/unpack.py <office_file> <output_directory>
+```
+
+### Pack
+```bash
+python ooxml/scripts/pack.py <input_directory> <office_file>
+```
+
+## Key XML Files
+
+- `word/document.xml` - Main document contents
+- `word/comments.xml` - Comments referenced in document.xml
+- `word/media/` - Embedded images and media files
+- Tracked changes: `<w:ins>` and `<w:del>` tags
+
+## Document Library (Python)
+
+**MANDATORY**: Read `ooxml.md` completely (~600 lines, no range limits) for:
+- Complete Document library API
+- XML patterns for editing
+- Tracked change patterns
+- Example scripts
+
+The Document library automatically handles infrastructure setup and provides:
+- High-level methods for common operations
+- Direct DOM access for complex scenarios
+- `get_node` for finding elements
+- `doc.save()` for persisting changes
+
+### Basic Pattern
+
+```python
+from ooxml import Document
+
+# Load unpacked document
+doc = Document("unpacked_dir")
+
+# Find and modify nodes
+node = doc.get_node("//w:p[1]")  # First paragraph
+# ... make changes ...
+
+# Save
+doc.save()
+```
+
+## Converting to Images
+
+**Two-step process**:
+
+1. Convert to PDF:
+```bash
+soffice --headless --convert-to pdf document.docx
+```
+
+2. Convert PDF to JPEG:
+```bash
+pdftoppm -jpeg -r 150 document.pdf page
+```
+
+Creates `page-1.jpg`, `page-2.jpg`, etc.
+
+**Options**:
+- `-r 150`: Resolution (DPI)
+- `-jpeg`: JPEG format (or `-png`)
+- `-f N`: First page
+- `-l N`: Last page
+- `page`: Output prefix
+
+Example for range:
+```bash
+pdftoppm -jpeg -r 150 -f 2 -l 5 document.pdf page  # Pages 2-5
+```
+
+## Code Style
+
+**IMPORTANT**:
+- Write concise code
+- Avoid verbose variable names
+- Avoid unnecessary print statements
+- Avoid redundant operations
+
+## Dependencies
+
+- **pandoc**: `sudo apt-get install pandoc` (text extraction)
+- **docx**: `npm install -g docx` (creating new documents)
+- **LibreOffice**: `sudo apt-get install libreoffice` (PDF conversion)
+- **Poppler**: `sudo apt-get install poppler-utils` (pdftoppm)
+- **defusedxml**: `pip install defusedxml` (secure XML parsing)
 """

--- a/src/pdf/src/pdf/__init__.py
+++ b/src/pdf/src/pdf/__init__.py
@@ -7,6 +7,6 @@ load_dotenv()
 
 mcp = FastMCP(os.getenv("NAME", "pdf"))
 
-from . import server, tools  # noqa: F401, E402
+from . import prompts, server, tools  # noqa: F401, E402
 
 __all__ = ["mcp"]

--- a/src/pdf/src/pdf/prompts.py
+++ b/src/pdf/src/pdf/prompts.py
@@ -1,0 +1,318 @@
+from . import mcp
+
+
+@mcp.prompt()
+def pdf_quick_reference() -> str:
+    """Quick reference for PDF operations and library selection."""
+    return """# PDF Quick Reference
+
+## Library Selection
+
+| Task | Best Tool | Command/Code |
+|------|-----------|--------------|
+| Merge PDFs | pypdf | `writer.add_page(page)` |
+| Split PDFs | pypdf | One page per file |
+| Extract text | pdfplumber | `page.extract_text()` |
+| Extract tables | pdfplumber | `page.extract_tables()` |
+| Create PDFs | reportlab | Canvas or Platypus |
+| Command line merge | qpdf | `qpdf --empty --pages ...` |
+| OCR scanned PDFs | pytesseract | Convert to image first |
+| Fill PDF forms | pdf-lib or pypdf | See forms workflow |
+
+## Common Operations
+
+**pypdf** - Basic operations (merge, split, rotate, metadata, passwords)
+**pdfplumber** - Text extraction with layout, table extraction
+**reportlab** - Create PDFs from scratch
+"""
+
+
+@mcp.prompt()
+def pdf_text_extraction() -> str:
+    """Detailed guidance on extracting text and tables from PDFs."""
+    return """# PDF Text Extraction
+
+## Using pdfplumber (Recommended)
+
+### Extract Text with Layout
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        print(text)
+```
+
+### Extract Tables
+```python
+with pdfplumber.open("document.pdf") as pdf:
+    for i, page in enumerate(pdf.pages):
+        tables = page.extract_tables()
+        for j, table in enumerate(tables):
+            print(f"Table {j+1} on page {i+1}:")
+            for row in table:
+                print(row)
+```
+
+### Advanced Table Extraction to Excel
+```python
+import pandas as pd
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    all_tables = []
+    for page in pdf.pages:
+        tables = page.extract_tables()
+        for table in tables:
+            if table:  # Check if table is not empty
+                df = pd.DataFrame(table[1:], columns=table[0])
+                all_tables.append(df)
+
+# Combine all tables
+if all_tables:
+    combined_df = pd.concat(all_tables, ignore_index=True)
+    combined_df.to_excel("extracted_tables.xlsx", index=False)
+```
+
+## Extract Text from Scanned PDFs (OCR)
+```python
+# Requires: pip install pytesseract pdf2image
+import pytesseract
+from pdf2image import convert_from_path
+
+# Convert PDF to images
+images = convert_from_path('scanned.pdf')
+
+# OCR each page
+text = ""
+for i, image in enumerate(images):
+    text += f"Page {i+1}:\\n"
+    text += pytesseract.image_to_string(image)
+    text += "\\n\\n"
+
+print(text)
+```
+
+## Using pypdf for Basic Text Extraction
+```python
+from pypdf import PdfReader
+
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+# Extract text
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```
+
+## Command-Line Tools
+
+### pdftotext (poppler-utils)
+```bash
+# Extract text
+pdftotext input.pdf output.txt
+
+# Extract text preserving layout
+pdftotext -layout input.pdf output.txt
+
+# Extract specific pages
+pdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5
+```
+"""
+
+
+@mcp.prompt()
+def pdf_creation() -> str:
+    """Patterns for creating PDFs with reportlab."""
+    return """# Creating PDFs with reportlab
+
+## Basic PDF Creation
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+c = canvas.Canvas("hello.pdf", pagesize=letter)
+width, height = letter
+
+# Add text
+c.drawString(100, height - 100, "Hello World!")
+c.drawString(100, height - 120, "This is a PDF created with reportlab")
+
+# Add a line
+c.line(100, height - 140, 400, height - 140)
+
+# Save
+c.save()
+```
+
+## Create PDF with Multiple Pages
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
+from reportlab.lib.styles import getSampleStyleSheet
+
+doc = SimpleDocTemplate("report.pdf", pagesize=letter)
+styles = getSampleStyleSheet()
+story = []
+
+# Add content
+title = Paragraph("Report Title", styles['Title'])
+story.append(title)
+story.append(Spacer(1, 12))
+
+body = Paragraph("This is the body of the report. " * 20, styles['Normal'])
+story.append(body)
+story.append(PageBreak())
+
+# Page 2
+story.append(Paragraph("Page 2", styles['Heading1']))
+story.append(Paragraph("Content for page 2", styles['Normal']))
+
+# Build PDF
+doc.build(story)
+```
+
+## Key Components
+
+**Canvas** - Low-level drawing API for precise positioning
+**Platypus** - High-level flowable document API
+**Styles** - Predefined styles for consistent formatting
+**PageBreak** - Force new page
+**Spacer** - Add vertical spacing
+"""
+
+
+@mcp.prompt()
+def pdf_manipulation() -> str:
+    """Common PDF manipulation operations."""
+    return """# PDF Manipulation
+
+## Merge PDFs
+```python
+from pypdf import PdfWriter, PdfReader
+
+writer = PdfWriter()
+for pdf_file in ["doc1.pdf", "doc2.pdf", "doc3.pdf"]:
+    reader = PdfReader(pdf_file)
+    for page in reader.pages:
+        writer.add_page(page)
+
+with open("merged.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Split PDF
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("input.pdf")
+for i, page in enumerate(reader.pages):
+    writer = PdfWriter()
+    writer.add_page(page)
+    with open(f"page_{i+1}.pdf", "wb") as output:
+        writer.write(output)
+```
+
+## Rotate Pages
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+page = reader.pages[0]
+page.rotate(90)  # Rotate 90 degrees clockwise
+writer.add_page(page)
+
+with open("rotated.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Extract Metadata
+```python
+from pypdf import PdfReader
+
+reader = PdfReader("document.pdf")
+meta = reader.metadata
+print(f"Title: {meta.title}")
+print(f"Author: {meta.author}")
+print(f"Subject: {meta.subject}")
+print(f"Creator: {meta.creator}")
+```
+
+## Add Watermark
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Create watermark (or load existing)
+watermark = PdfReader("watermark.pdf").pages[0]
+
+# Apply to all pages
+reader = PdfReader("document.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    page.merge_page(watermark)
+    writer.add_page(page)
+
+with open("watermarked.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Password Protection
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    writer.add_page(page)
+
+# Add password
+writer.encrypt("userpassword", "ownerpassword")
+
+with open("encrypted.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Extract Images
+```bash
+# Using pdfimages (poppler-utils)
+pdfimages -j input.pdf output_prefix
+
+# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.
+```
+
+## Command-Line Tools
+
+### qpdf
+```bash
+# Merge PDFs
+qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
+
+# Split pages
+qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
+qpdf input.pdf --pages . 6-10 -- pages6-10.pdf
+
+# Rotate pages
+qpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees
+
+# Remove password
+qpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf
+```
+
+### pdftk (if available)
+```bash
+# Merge
+pdftk file1.pdf file2.pdf cat output merged.pdf
+
+# Split
+pdftk input.pdf burst
+
+# Rotate
+pdftk input.pdf rotate 1east output rotated.pdf
+```
+"""

--- a/src/pptx/src/pptx_server/__init__.py
+++ b/src/pptx/src/pptx_server/__init__.py
@@ -7,6 +7,6 @@ load_dotenv()
 
 mcp = FastMCP(os.getenv("NAME", "pptx"))
 
-from . import html2pptx, server, tools  # noqa: F401, E402
+from . import html2pptx, prompts, server, tools  # noqa: F401, E402
 
 __all__ = ["mcp"]

--- a/src/pptx/src/pptx_server/prompts.py
+++ b/src/pptx/src/pptx_server/prompts.py
@@ -1,0 +1,381 @@
+from . import mcp
+
+
+@mcp.prompt()
+def pptx_workflow_overview() -> str:
+    """Decision tree for PPTX workflows - choosing the right approach."""
+    return """# PPTX Workflow Overview
+
+## Choosing Your Workflow
+
+### Reading and Analyzing Content
+- **Text extraction**: `markitdown path-to-file.pptx` - Convert to markdown
+- **Raw XML access**: Unpack with `python ooxml/scripts/unpack.py` for comments, speaker notes, layouts, animations
+
+### Creating New Presentation WITHOUT Template
+→ Use **html2pptx** workflow
+- Create HTML slides with proper dimensions (720pt × 405pt for 16:9)
+- Convert to PowerPoint with accurate positioning
+- Add charts/tables via PptxGenJS API
+- See `pptx_html2pptx()` prompt for details
+
+### Creating New Presentation WITH Template
+→ Use **template workflow**
+- Extract template text and create visual thumbnails
+- Analyze template inventory
+- Duplicate, reorder, delete slides
+- Replace placeholder text
+- See `pptx_template_workflow()` prompt for details
+
+### Editing Existing Presentation
+→ Use **OOXML editing** workflow
+- Unpack presentation to XML
+- Edit XML files (primarily slide{N}.xml)
+- Validate immediately after each edit
+- Pack final presentation
+- See `pptx_ooxml_editing()` prompt for details
+
+## Key File Structures (Unpacked PPTX)
+- `ppt/presentation.xml` - Main presentation metadata
+- `ppt/slides/slide{N}.xml` - Individual slide contents
+- `ppt/notesSlides/notesSlide{N}.xml` - Speaker notes
+- `ppt/comments/modernComment_*.xml` - Comments
+- `ppt/slideLayouts/` - Layout templates
+- `ppt/slideMasters/` - Master slide templates
+- `ppt/theme/` - Theme and styling
+- `ppt/media/` - Images and media
+"""
+
+
+@mcp.prompt()
+def pptx_html2pptx() -> str:
+    """HTML to PowerPoint creation workflow and design principles."""
+    return """# Creating PowerPoint with html2pptx
+
+## Design Principles (CRITICAL)
+
+**Before creating any presentation**, analyze the content and choose design elements:
+
+1. **Consider the subject matter**: What tone, industry, or mood does it suggest?
+2. **Check for branding**: Consider company/organization brand colors
+3. **Match palette to content**: Select colors that reflect the subject
+4. **State your approach**: Explain design choices before writing code
+
+**Requirements**:
+- ✅ State your content-informed design approach BEFORE writing code
+- ✅ Use web-safe fonts only: Arial, Helvetica, Times New Roman, Georgia, Courier New, Verdana, Tahoma, Trebuchet MS, Impact
+- ✅ Create clear visual hierarchy through size, weight, and color
+- ✅ Ensure readability: strong contrast, appropriately sized text, clean alignment
+- ✅ Be consistent: repeat patterns, spacing, visual language
+
+## Color Palette Selection
+
+**Think beyond defaults**:
+- Topic, industry, mood, energy level, target audience
+- Be adventurous - healthcare doesn't have to be green, finance doesn't have to be navy
+- Pick 3-5 colors that work together
+- Ensure contrast for readability
+
+**Example palettes** (for inspiration):
+1. Classic Blue: #1C2833, #2E4053, #AAB7B8, #F4F6F6
+2. Teal & Coral: #5EA8A7, #277884, #FE4447, #FFFFFF
+3. Bold Red: #C0392B, #E74C3C, #F39C12, #F1C40F, #2ECC71
+4. Burgundy Luxury: #5D1D2E, #951233, #C15937, #997929
+5. Deep Purple & Emerald: #B165FB, #181B24, #40695B, #FFFFFF
+6. Sage & Terracotta: #87A96B, #E07A5F, #F4F1DE, #2C2C2C
+
+## Layout Tips
+
+**For slides with charts or tables**:
+- **Two-column layout (PREFERRED)**: Header spanning full width, then columns (40%/60% split)
+- **Full-slide layout**: Let content take up entire slide for maximum impact
+- **NEVER vertically stack**: Don't place charts/tables below text in single column
+
+## Workflow
+
+1. **MANDATORY**: Read `html2pptx.md` completely (no range limits) for syntax and formatting rules
+2. Create HTML file for each slide (720pt × 405pt for 16:9)
+   - Use `<p>`, `<h1>`-`<h6>`, `<ul>`, `<ol>` for text
+   - Use `class="placeholder"` for chart/table areas
+   - **CRITICAL**: Rasterize gradients/icons as PNG using Sharp first
+3. Create JavaScript file using `html2pptx.js` library
+   - Use `html2pptx()` function
+   - Add charts/tables to placeholders via PptxGenJS API
+   - Save with `pptx.writeFile()`
+4. **Visual validation**: Generate thumbnails and inspect
+   - `python scripts/thumbnail.py output.pptx workspace/thumbnails --cols 4`
+   - Check for: text cutoff, overlap, positioning, contrast issues
+   - Adjust HTML and regenerate until correct
+
+## Visual Details Options
+
+**Typography**: Extreme size contrast, all-caps headers, monospace for data
+**Geometric**: Diagonal dividers, asymmetric columns, rotated text
+**Borders**: Thick single-color, L-shaped, corner brackets
+**Backgrounds**: Solid color blocks, split backgrounds, edge-to-edge bands
+**Charts**: Monochrome with accent color, horizontal bars, minimal gridlines
+"""
+
+
+@mcp.prompt()
+def pptx_ooxml_editing() -> str:
+    """OOXML-based editing workflow for existing presentations."""
+    return """# Editing Existing PowerPoint (OOXML)
+
+## Workflow
+
+1. **MANDATORY**: Read `ooxml.md` completely (~500 lines, no range limits)
+   - Detailed guidance on OOXML structure and editing
+2. **Unpack**: `python ooxml/scripts/unpack.py <office_file> <output_dir>`
+3. **Edit XML**: Primarily `ppt/slides/slide{N}.xml` and related files
+4. **CRITICAL - Validate**: After EACH edit, validate before proceeding
+   - `python ooxml/scripts/validate.py <dir> --original <file>`
+   - Fix any validation errors immediately
+5. **Pack**: `python ooxml/scripts/pack.py <input_directory> <office_file>`
+
+## Key XML Files
+
+**Slides**: `ppt/slides/slide1.xml`, `slide2.xml`, etc.
+**Notes**: `ppt/notesSlides/notesSlide1.xml`, etc.
+**Comments**: `ppt/comments/modernComment_*.xml`
+**Layouts**: `ppt/slideLayouts/` - Layout templates
+**Masters**: `ppt/slideMasters/` - Master slide templates
+**Theme**: `ppt/theme/theme1.xml` - Colors and fonts
+
+## Typography and Color Extraction
+
+**When emulating a design**:
+1. Read theme: `ppt/theme/theme1.xml` for `<a:clrScheme>` and `<a:fontScheme>`
+2. Sample slide: `ppt/slides/slide1.xml` for actual font usage (`<a:rPr>`)
+3. Search patterns: Use grep for color (`<a:solidFill>`, `<a:srgbClr>`) and fonts
+
+## Converting to Images
+
+**Two-step process**:
+1. Convert to PDF: `soffice --headless --convert-to pdf template.pptx`
+2. Convert PDF to JPEG: `pdftoppm -jpeg -r 150 template.pdf slide`
+   - Creates `slide-1.jpg`, `slide-2.jpg`, etc.
+   - Options: `-f N` (first page), `-l N` (last page), `-r 150` (resolution)
+"""
+
+
+@mcp.prompt()
+def pptx_template_workflow() -> str:
+    """Using existing templates to create new presentations."""
+    return """# Creating PowerPoint Using Templates
+
+## Workflow
+
+### 1. Extract Template Text and Create Thumbnails
+```bash
+# Extract text
+python -m markitdown template.pptx > template-content.md
+
+# Create thumbnail grids (for visual analysis)
+python scripts/thumbnail.py template.pptx
+```
+
+Read `template-content.md` completely (no range limits)
+
+### 2. Analyze Template and Save Inventory
+
+**Visual Analysis**: Review thumbnail grids for layouts, design patterns, structure
+
+Create `template-inventory.md`:
+```markdown
+# Template Inventory Analysis
+**Total Slides: [count]**
+**IMPORTANT: Slides are 0-indexed (first slide = 0, last = count-1)**
+
+## [Category Name]
+- Slide 0: [Layout code] - Description/purpose
+- Slide 1: [Layout code] - Description/purpose
+[... EVERY slide listed individually ...]
+```
+
+**Using thumbnails**: Identify layout patterns, image placeholders, design consistency
+
+### 3. Create Presentation Outline
+
+**CRITICAL - Match Layout to Content**:
+- Single-column: Unified narrative or single topic
+- Two-column: ONLY for exactly 2 distinct items
+- Three-column: ONLY for exactly 3 distinct items
+- Image + text: ONLY when you have actual images
+- Quote layouts: ONLY for actual quotes with attribution
+- Count content pieces BEFORE selecting layout
+- Don't force content into mismatched layouts
+
+Save `outline.md` with template mapping:
+```python
+# Template slides to use (0-based indexing)
+# WARNING: Verify indices within range! 73 slides = indices 0-72
+template_mapping = [
+    0,   # Title/Cover
+    34,  # Title and body
+    34,  # Duplicate for second slide
+    50,  # Quote
+    54,  # Closing + Text
+]
+```
+
+### 4. Rearrange Slides
+```bash
+python scripts/rearrange.py template.pptx working.pptx 0,34,34,50,52
+```
+
+### 5. Extract ALL Text Inventory
+```bash
+python scripts/inventory.py working.pptx text-inventory.json
+```
+
+Read `text-inventory.json` completely (no range limits)
+
+**Inventory structure**:
+- Slides: "slide-0", "slide-1", etc.
+- Shapes: Ordered visually as "shape-0", "shape-1"
+- Placeholder types: TITLE, CENTER_TITLE, SUBTITLE, BODY, OBJECT, or null
+- Properties: Only non-default values included
+
+### 6. Generate Replacement Text
+
+**CRITICAL**:
+- First verify which shapes exist in inventory
+- Validation shows errors for non-existent shapes/slides
+- ALL shapes cleared unless you provide "paragraphs"
+- Don't include "paragraphs" for shapes you want to clear
+- When `bullet: true`, DON'T include bullet symbols in text
+- Include paragraph properties from original inventory
+
+**Essential formatting**:
+- Headers/titles: `"bold": true`
+- List items: `"bullet": true, "level": 0`
+- Preserve alignment: `"alignment": "CENTER"`
+- Colors: `"color": "FF0000"` or `"theme_color": "DARK_1"`
+
+Example paragraphs:
+```json
+"paragraphs": [
+  {
+    "text": "New title",
+    "alignment": "CENTER",
+    "bold": true
+  },
+  {
+    "text": "Bullet point without symbol",
+    "bullet": true,
+    "level": 0
+  }
+]
+```
+
+Save to `replacement-text.json`
+
+### 7. Apply Replacements
+```bash
+python scripts/replace.py working.pptx replacement-text.json output.pptx
+```
+
+Validates shapes exist and applies formatting automatically
+
+## Creating Thumbnail Grids
+
+```bash
+# Basic usage
+python scripts/thumbnail.py template.pptx
+
+# Custom options
+python scripts/thumbnail.py template.pptx workspace/analysis --cols 4
+```
+
+**Features**:
+- Default: 5 columns, max 30 slides per grid
+- Range: 3-6 columns
+- Zero-indexed slide labels
+"""
+
+
+@mcp.prompt()
+def pptx_design_principles() -> str:
+    """Design principles and visual details for presentations."""
+    return """# PPTX Design Principles
+
+## Core Design Requirements
+
+1. **Content-First Design**
+   - Analyze subject matter before choosing design
+   - Consider: tone, industry, mood, target audience
+   - Match palette to content (don't use autopilot choices)
+   - State design approach BEFORE coding
+
+2. **Typography**
+   - Web-safe fonts ONLY: Arial, Helvetica, Times New Roman, Georgia, Courier New, Verdana, Tahoma, Trebuchet MS, Impact
+   - Clear visual hierarchy via size, weight, color
+   - Strong contrast for readability
+   - Consistent patterns across slides
+
+3. **Color Strategy**
+   - Think beyond defaults
+   - Be adventurous with combinations
+   - Pick 3-5 colors that work together
+   - Ensure text/background contrast
+
+## Visual Details Library
+
+### Typography Treatments
+- Extreme size contrast (72pt headlines vs 11pt body)
+- All-caps headers with wide letter spacing
+- Numbered sections in oversized display type
+- Monospace (Courier New) for data/stats
+- Outlined text for emphasis
+
+### Geometric Patterns
+- Diagonal section dividers
+- Asymmetric column widths (30/70, 40/60, 25/75)
+- Rotated text headers (90° or 270°)
+- Circular/hexagonal frames for images
+- Triangular accent shapes in corners
+- Overlapping shapes for depth
+
+### Border & Frame Treatments
+- Thick single-color borders (10-20pt) on one side
+- Double-line borders with contrasting colors
+- Corner brackets instead of full frames
+- L-shaped borders (top+left or bottom+right)
+- Underline accents beneath headers (3-5pt thick)
+
+### Chart & Data Styling
+- Monochrome charts with single accent color for key data
+- Horizontal bar charts instead of vertical
+- Dot plots instead of bar charts
+- Minimal gridlines or none
+- Data labels directly on elements (no legends)
+- Oversized numbers for key metrics
+
+### Layout Innovations
+- Full-bleed images with text overlays
+- Sidebar column (20-30% width) for navigation/context
+- Modular grid systems (3×3, 4×4 blocks)
+- Z-pattern or F-pattern content flow
+- Floating text boxes over colored shapes
+- Magazine-style multi-column layouts
+
+### Background Treatments
+- Solid color blocks occupying 40-60% of slide
+- Gradient fills (vertical or diagonal only)
+- Split backgrounds (two colors, diagonal or vertical)
+- Edge-to-edge color bands
+- Negative space as design element
+
+## Layout Best Practices
+
+**Charts/Tables**:
+- Two-column preferred: header + content side-by-side
+- Full-slide for maximum impact
+- Never vertical stack (chart below text)
+
+**Content Matching**:
+- Match layout structure to actual content count
+- Don't force 2 items into 3-column layout
+- Use appropriate placeholders for your content type
+"""


### PR DESCRIPTION
- Add prompts.py for PDF server with 4 focused prompts:
  - pdf_quick_reference: Library selection and common operations
  - pdf_text_extraction: Text and table extraction workflows
  - pdf_creation: reportlab patterns for creating PDFs
  - pdf_manipulation: Merge, split, rotate, watermark operations

- Add prompts.py for PPTX server with 5 focused prompts:
  - pptx_workflow_overview: Decision tree for choosing workflows
  - pptx_html2pptx: HTML to PowerPoint creation with design principles
  - pptx_ooxml_editing: OOXML-based editing for existing presentations
  - pptx_template_workflow: Using templates to create presentations
  - pptx_design_principles: Design guidelines and visual details

- Expand DOCX prompts.py from 1 to 4 prompts:
  - docx_workflow: Enhanced with workflow decision tree
  - docx_creation: New prompt for docx-js creation workflow
  - docx_redlining: New prompt for tracked changes workflow
  - docx_ooxml_reference: New prompt for OOXML editing patterns

This migration makes domain expertise available as standardized MCP prompts, enabling on-demand loading and model-agnostic usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)