### PR TITLE
feat: add GitHub Pages CI for titanic EDA demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,9 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
+    paths:
+      - 'examples/langquery/*.html'
+      - '.github/workflows/pages.yml'
   workflow_dispatch:
 
 permissions:
@@ -25,6 +28,14 @@ jobs:
 
       - name: Prepare site content
         run: |
+          if [ ! -f examples/langquery/titanic_eda.html ]; then
+            echo "Error: titanic_eda.html not found"
+            exit 1
+          fi
+          if [ ! -f examples/langquery/titanic_eda_ja.html ]; then
+            echo "Error: titanic_eda_ja.html not found"
+            exit 1
+          fi
           mkdir -p _site
           cp examples/langquery/titanic_eda.html _site/index.html
           cp examples/langquery/titanic_eda_ja.html _site/titanic_eda_ja.html


### PR DESCRIPTION
## Summary
- Add GitHub Pages workflow to deploy the titanic EDA demo
- Sets `titanic_eda.html` as the main index page
- Includes Japanese version (`titanic_eda_ja.html`)

## Setup Required
After merging, enable GitHub Pages in repository settings:
1. Go to Settings → Pages
2. Under "Build and deployment", select **GitHub Actions** as the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)