### PR TITLE
feat: add command line argument parsing to all MCP servers

### DIFF
--- a/DOCKER_PORTS.md
+++ b/DOCKER_PORTS.md
@@ -31,10 +31,15 @@ uv run python -m <server> --help
 
 | Argument         | Environment Variable | Default   | Description                       |
 |------------------|---------------------|-----------|-----------------------------------|
-| `--transport`    | `TRANSPORT`         | `stdio`   | Transport protocol (`stdio`, `sse`, `streamable-http`) |
+| `--transport`    | `TRANSPORT`         | `stdio`   | Transport protocol (see below) |
 | `--host`         | `HOST`              | `0.0.0.0` | Host to bind to                   |
 | `--port`         | `PORT`              | Server-specific | Port to listen on            |
 | `--allow-origin` | `ALLOW_ORIGIN`      | `*`       | CORS allowed origin               |
+
+**Transport protocols:**
+- `stdio` - Standard input/output (default, for CLI usage)
+- `sse` - Server-Sent Events over HTTP (for web clients)
+- `streamable-http` - HTTP with streaming support (alternative to SSE)
 
 ### Security Note
 

--- a/src/browser/src/browser/server.py
+++ b/src/browser/src/browser/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8007
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/dify/src/dify/server.py
+++ b/src/dify/src/dify/server.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import sys
 from contextlib import asynccontextmanager
 
 from fastmcp import FastMCP
@@ -49,6 +50,29 @@ mcp.add_tool(export_dsl_workflow)
 mcp.add_tool(generate_workflow_dsl)
 
 
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
+
+
 def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description="dify MCP Server")
@@ -65,8 +89,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/docx/src/docx/server.py
+++ b/src/docx/src/docx/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8005
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/file-management/src/file_management/server.py
+++ b/src/file-management/src/file_management/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8010
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/frontend-design/src/frontend_design/server.py
+++ b/src/frontend-design/src/frontend_design/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8009
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/langquery/src/langquery/server.py
+++ b/src/langquery/src/langquery/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8006
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/pdf/src/pdf/server.py
+++ b/src/pdf/src/pdf/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8008
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/pptx/src/pptx_server/server.py
+++ b/src/pptx/src/pptx_server/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8003
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/shell/src/shell/server.py
+++ b/src/shell/src/shell/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8011
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/vectorstore/src/vectorstore/server.py
+++ b/src/vectorstore/src/vectorstore/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8002
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/xlsx/src/xlsx/server.py
+++ b/src/xlsx/src/xlsx/server.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import sys
 
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -7,6 +8,29 @@ from starlette.middleware.cors import CORSMiddleware
 from . import mcp
 
 DEFAULT_PORT = 8004
+
+
+def _get_port_default() -> int:
+    """Get port from environment variable with validation."""
+    port_str = os.getenv("PORT")
+    if port_str is None:
+        return DEFAULT_PORT
+    try:
+        return int(port_str)
+    except ValueError:
+        print(f"Error: Invalid PORT environment variable '{port_str}'. Must be an integer.", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_port(value: str) -> int:
+    """Validate port is in valid range."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid integer")
+    if not (1 <= port <= 65535):
+        raise argparse.ArgumentTypeError(f"Port must be between 1 and 65535, got {port}")
+    return port
 
 
 def parse_args() -> argparse.Namespace:
@@ -25,8 +49,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--port",
-        type=int,
-        default=int(os.getenv("PORT", DEFAULT_PORT)),
+        type=_validate_port,
+        default=_get_port_default(),
         help=f"Port to listen on (default: {DEFAULT_PORT})",
     )
     parser.add_argument(

--- a/src/xlsx/tests/test_server.py
+++ b/src/xlsx/tests/test_server.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from xlsx.server import DEFAULT_PORT, parse_args
+from xlsx.server import DEFAULT_PORT, _validate_port, parse_args
 
 
 class TestParseArgs:
@@ -56,3 +56,48 @@ class TestParseArgs:
         with patch("sys.argv", ["server.py", "--allow-origin", "https://example.com"]):
             args = parse_args()
             assert args.allow_origin == "https://example.com"
+
+    def test_port_range_validation(self):
+        """Test port must be within valid range."""
+        with patch("sys.argv", ["server.py", "--port", "70000"]):
+            with pytest.raises(SystemExit):
+                parse_args()
+
+    def test_port_invalid_value(self):
+        """Test port rejects non-integer values."""
+        with patch("sys.argv", ["server.py", "--port", "abc"]):
+            with pytest.raises(SystemExit):
+                parse_args()
+
+    def test_invalid_port_env_var(self):
+        """Test invalid PORT environment variable causes exit."""
+        with patch.dict(os.environ, {"PORT": "not_a_number"}, clear=False):
+            with patch("sys.argv", ["server.py"]):
+                with pytest.raises(SystemExit):
+                    parse_args()
+
+
+class TestValidatePort:
+    """Tests for _validate_port function."""
+
+    def test_valid_port(self):
+        """Test valid port values."""
+        assert _validate_port("8080") == 8080
+        assert _validate_port("1") == 1
+        assert _validate_port("65535") == 65535
+
+    def test_port_out_of_range(self):
+        """Test port outside valid range raises error."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_port("0")
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_port("65536")
+
+    def test_invalid_port_string(self):
+        """Test non-numeric port raises error."""
+        import argparse
+
+        with pytest.raises(argparse.ArgumentTypeError):
+            _validate_port("abc")


### PR DESCRIPTION
## Summary

- Add `argparse`-based CLI argument parsing to all 12 MCP servers
- CLI arguments (`--transport`, `--host`, `--port`, `--allow-origin`) take precedence over environment variables
- Fix inconsistent default ports across servers
- Update `DOCKER_PORTS.md` with CLI usage documentation and missing servers

## Changes

### All server.py files now support:
```bash
uv run python -m <server> --help
uv run python -m xlsx --transport sse --port 9000
```

### Port assignments (fixed inconsistencies):
| Server | Port |
|--------|------|
| composite | 8000 |
| dify | 8001 |
| vectorstore | 8002 |
| pptx | 8003 |
| xlsx | 8004 |
| docx | 8005 |
| langquery | 8006 |
| browser | 8007 |
| pdf | 8008 |
| frontend-design | 8009 |
| file-management | 8010 |
| shell | 8011 |

## Test plan

- [x] All existing tests pass (browser tests require Playwright installation)
- [x] Lint and format checks pass
- [x] Manual test: `uv run python -m xlsx --help` shows usage
- [x] Manual test: `uv run python -m xlsx --transport sse --port 9000` starts server on port 9000

🤖 Generated with [Claude Code](https://claude.com/claude-code)