### PR TITLE
docs: make README and guides match the code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ When adding a new MCP server to the workspace:
 Default ports are assigned alphabetically, with composite reserved at 8000:
 
 - **composite**: 8000 (reserved for the aggregator server)
-- **Other servers**: 8001-8012, assigned alphabetically by server name
+- **Other servers**: 8001-8016, assigned alphabetically by server name
 
 When adding a new server, assign the next available port after the last alphabetically-sorted server. See `docs/server-guide.md` for the current port assignments.
 
@@ -209,7 +209,7 @@ This repository uses a **Google-style monorepo** with `uv` workspaces for unifie
 - Install all dependencies: `uv sync --dev` (run from root)
 - Add global dependency: Edit root `pyproject.toml`, then run `uv lock && uv sync --dev`
 - Add server-specific dependency: Edit `src/<server>/pyproject.toml`, then run `uv lock && uv sync --dev`
-- Run server: `cd src/<server> && uv run fastmcp run server.py`
+- Run server: `cd src/<server> && uv run python -m <module>`
 - Run tests: `cd src/<server> && uv run pytest -v`
 
 **Benefits:**

--- a/README.md
+++ b/README.md
@@ -1,137 +1,103 @@
 # MCP Servers
 
-17 Model Context Protocol (MCP) servers in daily use — browser automation, document processing, data operations, and AI integrations.
+A monorepo of 17 [Model Context Protocol](https://modelcontextprotocol.io/) servers built with [FastMCP](https://github.com/jlowin/fastmcp), covering browser automation, document processing, data analysis, and AI service integrations. Each server runs standalone or mounted behind a single composite endpoint.
 
-## Overview
+## Servers
 
-This monorepo contains multiple MCP servers built with [FastMCP](https://github.com/jlowin/fastmcp), each specialized for different tasks. All servers follow consistent patterns and can be deployed individually or as a composite server.
+| Server | Module | Port | Description |
+|--------|--------|------|-------------|
+| [composite](src/composite) | `composite` | 8000 | Aggregates the other servers into one endpoint |
+| [browser](src/browser) | `browser` | 8001 | Browser automation using Playwright |
+| [data-analysis](src/data-analysis) | `data_analysis` | 8002 | SQL data analysis with DuckDB |
+| [dify](src/dify) | `dify` | 8003 | Dify AI workflow integration |
+| [docx](src/docx) | `docx` | 8004 | Word document operations |
+| [file-management](src/file-management) | `file_management` | 8005 | File read/write operations |
+| [frontend-design](src/frontend-design) | `frontend_design` | 8006 | Design themes and color palettes |
+| [img2pptx](src/img2pptx) | `img2pptx` | 8007 | Image to PPTX conversion via OpenAI vision |
+| [nano-banana](src/nano-banana) | `nano_banana` | 8008 | AI image generation with Google Gemini |
+| [o3](src/o3) | `o3_search` | 8009 | Deep research with OpenAI o3 web search |
+| [pdf](src/pdf) | `pdf` | 8010 | PDF extraction and manipulation |
+| [pptx](src/pptx) | `pptx_mcp` | 8011 | PowerPoint operations |
+| [preview](src/preview) | `preview` | 8012 | HTML preview with live reload |
+| [shell](src/shell) | `shell` | 8013 | Shell command execution with an allowlist |
+| [skills](src/skills) | `skills` | 8014 | Claude skills discovery and loading |
+| [vectorstore](src/vectorstore) | `vectorstore` | 8015 | ChromaDB vector operations |
+| [xlsx](src/xlsx) | `xlsx` | 8016 | Excel spreadsheet operations |
 
-## Available Servers
-
-| Server | Port | Description |
-|--------|------|-------------|
-| [composite](src/composite) | 8000 | Combines multiple MCP servers into one |
-| [browser](src/browser) | 8001 | Browser automation using Playwright |
-| [data-analysis](src/data-analysis) | 8002 | SQL data analysis with DuckDB |
-| [dify](src/dify) | 8003 | Dify AI workflow integration |
-| [docx](src/docx) | 8004 | Word document operations |
-| [file-management](src/file-management) | 8005 | File read/write operations |
-| [frontend-design](src/frontend-design) | 8006 | Design themes and color palettes |
-| [img2pptx](src/img2pptx) | 8007 | Image to PPTX conversion |
-| [nano-banana](src/nano-banana) | 8008 | AI image generation with Google Gemini |
-| [o3](src/o3) | 8009 | Deep research with OpenAI o3 |
-| [pdf](src/pdf) | 8010 | PDF extraction and manipulation |
-| [pptx](src/pptx) | 8011 | PowerPoint operations |
-| [preview](src/preview) | 8012 | HTML preview with live reload |
-| [shell](src/shell) | 8013 | Shell command execution |
-| [skills](src/skills) | 8014 | Claude skills discovery and loading |
-| [vectorstore](src/vectorstore) | 8015 | ChromaDB vector operations |
-| [xlsx](src/xlsx) | 8016 | Excel spreadsheet operations |
+A shared `core` package (`src/core`) provides the CLI argument parsing and transport startup used by every server.
 
 ## Quick Start
 
-### Requirements
-
-- Python 3.12+
-- [uv](https://github.com/astral-sh/uv) for package management
-
-### Installation
+Requirements: Python 3.12+ and [uv](https://github.com/astral-sh/uv).
 
 ```bash
-# Install all dependencies
-uv sync --dev
+git clone https://github.com/yoichiojima-2/mcp-servers.git
+cd mcp-servers
+uv sync --all-packages --dev
 ```
 
-### Running a Server
+Run any server by its module name (see table above):
 
 ```bash
-# Using uv (recommended)
-uv run python -m <module_name>
-
-# Examples
-uv run python -m xlsx                    # Run xlsx server (stdio)
-uv run python -m xlsx --transport sse    # Run with SSE transport
+uv run python -m xlsx                    # stdio transport (default)
+uv run python -m xlsx --transport sse    # SSE transport
 ```
 
-### Docker (Optional)
+All servers accept the same CLI options — `--transport {stdio,sse,streamable-http}`, `--host`, `--port`, `--allow-origin` — or the equivalent `TRANSPORT`, `HOST`, `PORT`, `ALLOW_ORIGIN` environment variables.
+
+Each server also ships a Dockerfile and `docker-compose.yml`:
 
 ```bash
 cd src/<server>
 docker compose up
 ```
 
-## CLI Options
+See [docs/quickstart.md](docs/quickstart.md) for Claude Desktop integration and [.env.example](.env.example) for the API keys some servers require.
 
-All servers support these command-line arguments:
+## Architecture
 
-```bash
-uv run python -m <module> --help
+This is a `uv` workspace monorepo: one root `pyproject.toml` and a single `uv.lock` pin consistent dependency versions across all packages, while each server declares only its own extra dependencies.
 
-Options:
-  --transport {stdio,sse,streamable-http}  Transport protocol (default: stdio)
-  --host HOST                               Host to bind to (default: 0.0.0.0)
-  --port PORT                               Port to listen on (server-specific default)
-  --allow-origin ORIGIN                     CORS allowed origin (default: *)
-```
-
-Environment variables (`TRANSPORT`, `HOST`, `PORT`, `ALLOW_ORIGIN`) can be used instead of CLI arguments.
-
-## Project Structure
+The **composite server** implements an aggregator pattern. Driven by [composite-config.yaml](src/composite/composite-config.yaml), it imports each enabled server's FastMCP instance and mounts it under a tool prefix (`browser_navigate`, `data_query`, ...), so a client like Claude Desktop needs a single MCP connection instead of one per server. Servers can be toggled per deployment by flipping `enabled` in the config.
 
 ```
 mcp-servers/
 ├── src/
-│   ├── core/           # Shared CLI utilities
+│   ├── core/           # Shared CLI and transport utilities
 │   ├── browser/        # Individual server packages
 │   ├── data-analysis/
 │   ├── ...
-│   └── composite/      # Aggregates all servers
-├── docs/               # Shared documentation
-├── pyproject.toml      # Root workspace config
-└── uv.lock             # Unified lock file
+│   └── composite/      # Mounts enabled servers behind one endpoint
+├── docs/               # Quickstart and server guide
+├── examples/           # Claude Desktop / Dify configs, sample output
+├── pyproject.toml      # Workspace root
+└── uv.lock             # Single lock file for all packages
 ```
 
-This repository uses a **Google-style monorepo** with `uv` workspaces:
+## Testing and CI
 
-- **Root `pyproject.toml`**: Global dependencies (fastmcp, python-dotenv, pytest, ruff)
-- **Server `pyproject.toml`**: Server-specific dependencies
-- **Single `uv.lock`**: Consistent versions across all servers
-
-## Testing
+Each server has its own test suite under `src/<server>/tests/`. Run them from the server directory:
 
 ```bash
-# Run tests for a specific server
 cd src/<server>
 uv run pytest -v
-
-# Run all tests from root
-uv run pytest
 ```
 
-## Development
+GitHub Actions runs the full matrix — every server's tests plus a lockfile freshness check — on each push and pull request ([.github/workflows/test.yml](.github/workflows/test.yml)).
 
-See [CLAUDE.md](CLAUDE.md) for development guidelines and [docs/server-guide.md](docs/server-guide.md) for detailed server documentation.
-
-### Adding a New Server
-
-1. Create directory structure under `src/<server-name>/`
-2. Add to workspace members in root `pyproject.toml`
-3. Add to `.github/workflows/test.yml` if needed
-4. Optionally add to `src/composite/composite-config.yaml`
-
-### Linting
+Lint and format with ruff:
 
 ```bash
 uv run ruff check --fix
 uv run ruff format
 ```
 
-## Resources
+## Development
 
-- [MCP Documentation](https://modelcontextprotocol.io/)
-- [FastMCP Framework](https://github.com/jlowin/fastmcp)
-- [uv Package Manager](https://github.com/astral-sh/uv)
+See [CLAUDE.md](CLAUDE.md) for contribution guidelines and [docs/server-guide.md](docs/server-guide.md) for detailed per-server reference.
+
+To add a new server: create `src/<server-name>/`, register it in the root `pyproject.toml` workspace members and the CI matrix, and optionally add it to `src/composite/composite-config.yaml`.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ Some servers require API keys. Add them to your Claude Desktop config (see below
 | vectorstore | `OPENAI_API_KEY` |
 | dify | `DIFY_API_KEY` |
 
-**No API keys needed:** data-analysis, xlsx, pdf, docx, pptx, frontend-design, browser, preview, shell, skills
+**No API keys needed:** data-analysis, xlsx, pdf, docx, pptx, file-management, frontend-design, browser, preview, shell, skills
 
 ### 4. Run the server
 
@@ -70,8 +70,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
   "mcpServers": {
     "mcp-servers": {
       "command": "uv",
-      "args": ["run", "python", "-m", "composite"],
-      "cwd": "/absolute/path/to/mcp-servers/src/composite",
+      "args": ["run", "--directory", "/absolute/path/to/mcp-servers/src/composite", "python", "-m", "composite"],
       "env": {
         "GEMINI_API_KEY": "your-key",
         "OPENAI_API_KEY": "your-key"
@@ -98,16 +97,17 @@ Each server's tools are namespaced with a prefix:
 |--------|--------|---------|
 | browser | `browser_` | `browser_navigate` |
 | data-analysis | `data_` | `data_query` |
-| dify | `dify_` | `dify_chat` |
-| docx | `docx_` | `docx_create` |
-| frontend-design | `design_` | `design_palette` |
-| img2pptx | `img2pptx_` | `img2pptx_convert` |
-| nano-banana | `img_` | `img_generate` |
+| dify | `dify_` | `dify_chat_message` |
+| docx | `docx_` | `docx_unpack` |
+| file-management | `file_` | `file_read_file` |
+| frontend-design | `design_` | `design_design_list_themes` |
+| img2pptx | `img2pptx_` | `img2pptx_image_to_pptx` |
+| nano-banana | `img_` | `img_generate_image` |
 | o3 | `o3_` | `o3_o3` |
-| pdf | `pdf_` | `pdf_extract` |
-| pptx | `pptx_` | `pptx_create` |
-| preview | `preview_` | `preview_show` |
-| shell | `shell_` | `shell_run` |
+| pdf | `pdf_` | `pdf_extract_text` |
+| pptx | `pptx_` | `pptx_extract_text` |
+| preview | `preview_` | `preview_serve_html` |
+| shell | `shell_` | `shell_shell` |
 | skills | `skills_` | `skills_list_skills` |
-| vectorstore | `vec_` | `vec_search` |
-| xlsx | `xlsx_` | `xlsx_read` |
+| vectorstore | `vec_` | `vec_query` |
+| xlsx | `xlsx_` | `xlsx_read_excel` |

--- a/docs/server-guide.md
+++ b/docs/server-guide.md
@@ -7,8 +7,8 @@ This guide covers common operations for all MCP servers in this monorepo.
 All servers share the same installation process using `uv`:
 
 ```bash
-# Install all dependencies
-uv sync --dev
+# Install all servers and dependencies (run from the repo root)
+uv sync --all-packages --dev
 
 # Or install a specific server
 uv sync --package <server-name>
@@ -137,13 +137,11 @@ Named volumes persist across container restarts and removals. Data is only delet
 
 ## Testing
 
+Tests run per server, from the server directory (this is also how CI runs them):
+
 ```bash
-# Run tests for a specific server
 cd src/<server-name>
 uv run pytest -v
-
-# Run all tests
-uv run pytest
 ```
 
 ## Claude Desktop Configuration
@@ -297,9 +295,9 @@ Old environment variables (`WORKSPACE`, `DATA_ANALYSIS_WORKSPACE`, `BROWSER_WORK
    - Remove `BROWSER_WORKSPACE`
    - Remove `PREVIEW_WORKSPACE`
 
-3. (Optional) Download sample datasets for testing:
+3. (Optional) Download a sample dataset for testing:
    ```bash
-   ./scripts/download-sample-data.sh
+   ./src/data-analysis/bin/download_titanic.sh
    ```
 
 **File naming best practices**: With all servers sharing a workspace, use descriptive filenames to avoid conflicts:

--- a/examples/config/claude-desktop/README.md
+++ b/examples/config/claude-desktop/README.md
@@ -4,15 +4,14 @@ Example configuration for using MCP servers with Claude Desktop.
 
 ## Setup
 
-1. Copy `claude_desktop_config.json` to Claude Desktop config directory:
+1. Copy `claude_desktop_config.json` to the Claude Desktop config directory:
    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
    - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
    - Linux: `~/.config/Claude/claude_desktop_config.json`
 
-2. Update paths and tokens (use absolute paths):
-   - Replace `/path/to/mcp-servers` with your actual repo path (e.g., `/Users/yo/Developer/mcp-servers`)
-   - Replace `/path/to/documents` and `/path/to/desktop` with directories you want Claude to access
-   - Replace `<your-github-token>` with your GitHub personal access token
+2. Update paths (use absolute paths):
+   - Replace `/path/to/mcp-servers` with your actual repo path
+   - Replace `/Users/username/.mcp-servers` with the directory you want the filesystem server to access
 
 3. Restart Claude Desktop
 
@@ -20,17 +19,16 @@ Example configuration for using MCP servers with Claude Desktop.
 
 ### From this repository
 
-- **composite**: Aggregates MCP servers from this repo. Default enabled: shell, skills. Edit `src/composite/composite-config.yaml` to enable additional servers (data-analysis, xlsx, pdf, docx, pptx, vectorstore, browser, dify, frontend-design, nano-banana, o3, preview, img2pptx).
+- **composite**: Aggregates MCP servers from this repo. Edit `src/composite/composite-config.yaml` to choose which servers are enabled.
+- **shell**: Standalone shell server with an explicit command allowlist (`ALLOWED_COMMANDS`).
 
 ### External MCP Servers
 
 - **filesystem**: File read/write operations ([docs](https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem))
-- **github**: GitHub API integration ([docs](https://github.com/modelcontextprotocol/servers/tree/main/src/github))
 - **memory**: Persistent memory/knowledge graph ([docs](https://github.com/modelcontextprotocol/servers/tree/main/src/memory))
-- **fetch**: Web fetching capabilities ([docs](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch))
 
 ## Security
 
-- Never commit your actual config with real tokens to version control
+- Never commit a config containing real tokens or keys to version control
 - Keep your personal `claude_desktop_config.json` only in Claude's config directory
 - Consider using environment variables for sensitive values

--- a/examples/config/dify/README.md
+++ b/examples/config/dify/README.md
@@ -4,13 +4,14 @@ Example configuration for using MCP servers with [Dify](https://dify.ai/).
 
 ## Setup
 
-1. Start the MCP servers from the repository root:
+1. Start the servers with SSE transport. The simplest option is the composite server via Docker:
    ```bash
-   cd /path/to/mcp-servers
+   cd /path/to/mcp-servers/src/composite
    docker compose up -d
-
-   # Or start specific services only:
-   docker compose up -d composite data-analysis xlsx
+   ```
+   Or run any server directly:
+   ```bash
+   uv run python -m shell --transport sse
    ```
 
 2. In Dify, navigate to **Tools** > **MCP**
@@ -19,27 +20,15 @@ Example configuration for using MCP servers with [Dify](https://dify.ai/).
 
 ## Configuration
 
-The `dify-mcp-settings.json` file in this directory contains SSE endpoints for all servers:
+`dify-mcp-settings.json` contains SSE endpoints for:
 
 | Server | Port | Description |
 |--------|------|-------------|
-| composite | 8000 | All servers aggregated |
-| browser | 8001 | Browser automation |
-| data-analysis | 8002 | DuckDB SQL queries |
-| dify | 8003 | Dify workflow integration |
-| docx | 8004 | Word document operations |
-| frontend-design | 8006 | Design principles & themes |
-| img2pptx | 8007 | Image to PPTX conversion |
-| nano-banana | 8008 | AI image generation |
-| o3 | 8009 | AI-powered web search |
-| pdf | 8010 | PDF operations |
-| pptx | 8011 | PowerPoint operations |
-| preview | 8012 | HTML preview server |
+| composite | 8000 | Enabled servers aggregated behind one endpoint |
 | shell | 8013 | Shell command execution |
-| skills | 8014 | Claude skills discovery |
-| vectorstore | 8015 | Vector database |
-| xlsx | 8016 | Excel operations |
+
+Each server has a fixed default port (see the Server Reference in [docs/server-guide.md](../../../docs/server-guide.md)), so you can add more entries following the same pattern.
 
 ## Note
 
-When running in Docker, use `host.docker.internal` to connect to the host machine (as shown in the config file).
+When Dify runs in Docker, use `host.docker.internal` to reach servers on the host machine (as shown in the config file).


### PR DESCRIPTION
Docs accuracy pass: the README quickstart and several guides had drifted from the code.

- README: rewritten server table (adds the module column, verified ports 8000–8016), working quickstart — `uv sync --dev` from root does not install workspace members; `uv sync --all-packages` does — composite architecture note, and an accurate CI section
- CLAUDE.md: port range 8001–8016, correct `python -m <module>` run command
- docs/quickstart.md: Claude Desktop snippet used an unsupported `cwd` key → `uv --directory`; tool-prefix table now lists real tool names verified against `@mcp.tool` definitions
- docs/server-guide.md: install command, removed a dead script reference
- examples: claude-desktop and dify config READMEs now describe the actual JSON they ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)