### PR TITLE
fix: clear_query_history failed on current DuckDB

### DIFF
--- a/src/data-analysis/src/data_analysis/db.py
+++ b/src/data-analysis/src/data_analysis/db.py
@@ -372,14 +372,11 @@ class HistoryDB:
                 # More efficient than RETURNING which creates a result set for each deleted row
                 count = conn.execute("SELECT COUNT(*) FROM query_history").fetchone()[0]
 
-                # Delete all history
+                # Delete all history. The id sequence keeps counting from where it
+                # was: DuckDB supports neither ALTER SEQUENCE RESTART nor dropping a
+                # sequence the table's DEFAULT depends on (DROP ... CASCADE would
+                # take the table with it), and continuing ids are harmless.
                 conn.execute("DELETE FROM query_history")
-
-                # Reset the sequence to start from 1 again
-                # This prevents ID gaps and potential sequence exhaustion over time
-                # DuckDB doesn't support ALTER SEQUENCE RESTART, so we drop and recreate
-                conn.execute("DROP SEQUENCE IF EXISTS query_history_id_seq")
-                conn.execute("CREATE SEQUENCE query_history_id_seq START 1")
 
                 conn.execute("COMMIT")
             except Exception:


### PR DESCRIPTION
`clear_query_history` in the data-analysis server raised a ToolError on DuckDB 1.5.x:

```
Dependency Error: Cannot drop entry "query_history_id_seq" because there are entries that depend on it.
```

The handler tried to reset ids by dropping and recreating the sequence, but the table's `DEFAULT nextval(...)` depends on it. `DROP ... CASCADE` is not an option — verified it drops the dependent table — and `ALTER SEQUENCE RESTART` is still unimplemented in DuckDB. Since nothing relies on ids restarting at 1, the fix deletes the rows and leaves the sequence alone.

Before: 2 failed, 21 passed · After: 23 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)